### PR TITLE
index create complete !

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
 thothica
 .thothica
-
+*.json
 dist/

--- a/cmd/index/create.go
+++ b/cmd/index/create.go
@@ -1,10 +1,13 @@
 package index
 
 import (
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )
 
 var (
+	Pipeline  string
 	createCmd = &cobra.Command{
 		Use:   "create",
 		Short: "Creates a index for semantic search.",
@@ -13,3 +16,57 @@ var (
 		},
 	}
 )
+
+func init() {
+	createCmd.Flags().StringVarP(&Pipeline, "pipeline", "p", "", "Name of embedding pipeline for this index.")
+	createCmd.MarkFlagRequired("pipeline")
+}
+
+type index struct {
+	Settings struct {
+		IndexKNN        bool   `json:"index.knn"`
+		DefaultPipeline string `json:"default_pipeline"`
+	} `json:"settings"`
+	Mappings struct {
+		Properties []map[string]interface{} `json:"properties"`
+	} `json:"mappings"`
+}
+
+type model struct {
+	mappingFieldTypes []string
+	neuralSearchIndex index
+	cursor            int
+	selectionComplete bool
+	fieldInput        textinput.Model
+}
+
+func initialModel() model {
+	input := textinput.New()
+	input.Placeholder = "Input your field name."
+	input.Focus()
+
+	return model{
+		mappingFieldTypes: []string{"binary", "boolean", "ip", "object", "nested", "keyword", "text", "date"},
+		cursor:            0,
+		neuralSearchIndex: index{
+			Settings: struct {
+				IndexKNN        bool   "json:\"index.knn\""
+				DefaultPipeline string "json:\"default_pipeline\""
+			}{IndexKNN: true, DefaultPipeline: Pipeline},
+		},
+		selectionComplete: false,
+		fieldInput:        input,
+	}
+}
+
+func (m model) Init() tea.Cmd {
+	return nil
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	return nil, nil
+}
+
+func (m model) View() string {
+	return ""
+}

--- a/cmd/index/create.go
+++ b/cmd/index/create.go
@@ -1,14 +1,13 @@
 package index
 
 import (
-	"github.com/charmbracelet/bubbles/textinput"
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 )
 
 var (
-	Pipeline  string
-	createCmd = &cobra.Command{
+	Pipeline    string
+	VectorIndex string
+	createCmd   = &cobra.Command{
 		Use:   "create",
 		Short: "Creates a index for semantic search.",
 		Long:  `create (thothica index create) is a tool which helps you to define mappings and create index in opensearch to perform semantic search.`,
@@ -20,6 +19,8 @@ var (
 func init() {
 	createCmd.Flags().StringVarP(&Pipeline, "pipeline", "p", "", "Name of embedding pipeline for this index.")
 	createCmd.MarkFlagRequired("pipeline")
+	createCmd.Flags().StringVarP(&VectorIndex, "vector-index", "v", "", "Name of mapping/column which will hold embeddings as defined in the pipeline ")
+	createCmd.MarkFlagRequired("vector-index")
 }
 
 type index struct {
@@ -30,43 +31,4 @@ type index struct {
 	Mappings struct {
 		Properties []map[string]interface{} `json:"properties"`
 	} `json:"mappings"`
-}
-
-type model struct {
-	mappingFieldTypes []string
-	neuralSearchIndex index
-	cursor            int
-	selectionComplete bool
-	fieldInput        textinput.Model
-}
-
-func initialModel() model {
-	input := textinput.New()
-	input.Placeholder = "Input your field name."
-	input.Focus()
-
-	return model{
-		mappingFieldTypes: []string{"binary", "boolean", "ip", "object", "nested", "keyword", "text", "date"},
-		cursor:            0,
-		neuralSearchIndex: index{
-			Settings: struct {
-				IndexKNN        bool   "json:\"index.knn\""
-				DefaultPipeline string "json:\"default_pipeline\""
-			}{IndexKNN: true, DefaultPipeline: Pipeline},
-		},
-		selectionComplete: false,
-		fieldInput:        input,
-	}
-}
-
-func (m model) Init() tea.Cmd {
-	return nil
-}
-
-func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	return nil, nil
-}
-
-func (m model) View() string {
-	return ""
 }

--- a/cmd/index/create.go
+++ b/cmd/index/create.go
@@ -7,6 +7,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Thothica/thothica/internal/opensearch"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textarea"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
 
@@ -21,13 +26,17 @@ type index struct {
 }
 
 var (
-	Pipeline    string
-	VectorIndex string
-	Filename    string
-	data        []map[string]interface{}
-    BadFormatError = errors.New("Wrong file format, only json file of format - \n \t[{\"data_key\":\"data_value\", ..}..{}] are accepted")
-	i           index
-	createCmd   = &cobra.Command{
+	Pipeline       string
+	VectorIndex    string
+	Filename       string
+	Index          string
+	IndexBody      string
+	data           []map[string]interface{}
+	i              index
+	magentaStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+	c              = opensearch.NewClient()
+	BadFormatError = errors.New("Wrong file format, only json file of format - \n \t[{\"data_key\":\"data_value\", ..}..{}] are accepted")
+	createCmd      = &cobra.Command{
 		Use:   "create",
 		Short: "Creates a index for semantic search.",
 		Long:  `create (thothica index create) is a tool which helps you to define mappings and create index in opensearch to perform semantic search.`,
@@ -47,6 +56,11 @@ var (
 			err = json.NewDecoder(file).Decode(&data)
 			if err != nil {
 				cobra.CheckErr(err)
+			}
+
+			i.Mappings.Properties[VectorIndex] = map[string]interface{}{
+				"type":      "knn_vector",
+				"dimension": 768,
 			}
 
 			for k, v := range data[0] {
@@ -71,7 +85,11 @@ var (
 				cobra.CheckErr(err)
 			}
 
-			fmt.Println(string(IndexJson))
+			IndexBody = string(IndexJson)
+
+			if _, err := tea.NewProgram(initialModel()).Run(); err != nil {
+				cobra.CheckErr(err)
+			}
 		},
 	}
 )
@@ -83,10 +101,102 @@ func init() {
 	createCmd.MarkFlagRequired("vector-index")
 	createCmd.Flags().StringVarP(&Filename, "file", "f", "", "Path of file containing data for semantic search.\n Json file should be of format - \n \t[{\"data_key\":\"data_value\", ..}..{}]")
 	createCmd.MarkFlagRequired("vector-index")
+	createCmd.Flags().StringVarP(&Index, "index", "i", "", "Name of index you are creating.")
+	createCmd.MarkFlagRequired("index")
 }
 
 func InitialseIndex(i *index) {
 	i.Settings.IndexKNN = true
 	i.Settings.DefaultPipeline = Pipeline
 	i.Mappings.Properties = make(map[string]interface{})
+}
+
+type apiResponse string
+type apiError error
+
+type model struct {
+	textarea    textarea.Model
+	spinner     spinner.Model
+	loading     bool
+	apiResponse string
+}
+
+func CreateIndex(Body, Index string) tea.Cmd {
+	return func() tea.Msg {
+		res, err := c.CreateIndex(Body, Index)
+		if err != nil {
+			return apiError(err)
+		}
+		return apiResponse(res)
+	}
+}
+
+func initialModel() model {
+	t := textarea.New()
+	t.Focus()
+	t.SetHeight(25)
+	t.CharLimit = 0
+	t.SetValue(IndexBody)
+	t.FocusedStyle.CursorLine = magentaStyle
+
+	return model{
+		textarea:    t,
+		apiResponse: "",
+	}
+}
+
+func (m model) Init() tea.Cmd {
+	return textarea.Blink
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c":
+			return m, tea.Quit
+		case "ctrl+s":
+			m.loading = true
+			return m, tea.Batch(m.spinner.Tick, CreateIndex(m.textarea.Value(), Index))
+		}
+	default:
+		if !m.textarea.Focused() {
+			cmd = m.textarea.Focus()
+			cmds = append(cmds, cmd)
+		}
+
+	case apiError:
+		m.loading = false
+		m.apiResponse = msg.Error()
+		return m, tea.Quit
+
+	case apiResponse:
+		m.loading = false
+		m.apiResponse = string(msg)
+		return m, tea.Quit
+	}
+
+	m.textarea, cmd = m.textarea.Update(msg)
+	cmds = append(cmds, cmd)
+	return m, tea.Batch(cmds...)
+}
+
+func (m model) View() string {
+	var b strings.Builder
+
+	if m.loading {
+		fmt.Fprintf(&b, "\n %s Creating Index...\n\n", m.spinner.View())
+		return b.String()
+	}
+
+	if m.apiResponse != "" {
+		b.WriteString(m.apiResponse)
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "\n%s\n\n%s\n\n(press ctrl+c to abort or %s to create Index)", magentaStyle.Copy().Render("Edit Index as you like!"), m.textarea.View(), magentaStyle.Copy().Render("ctrl+s"))
+	return b.String()
 }

--- a/cmd/index/create.go
+++ b/cmd/index/create.go
@@ -17,11 +17,15 @@ type index struct {
 var (
 	Pipeline    string
 	VectorIndex string
+	Filename    string
+	data        []map[string]interface{}
+	i           index
 	createCmd   = &cobra.Command{
 		Use:   "create",
 		Short: "Creates a index for semantic search.",
 		Long:  `create (thothica index create) is a tool which helps you to define mappings and create index in opensearch to perform semantic search.`,
 		Run: func(cmd *cobra.Command, args []string) {
+			InitialseIndex(&i)
 		},
 	}
 )
@@ -29,16 +33,14 @@ var (
 func init() {
 	createCmd.Flags().StringVarP(&Pipeline, "pipeline", "p", "", "Name of embedding pipeline for this index.")
 	createCmd.MarkFlagRequired("pipeline")
-	createCmd.Flags().StringVarP(&VectorIndex, "vector-index", "v", "", "Name of mapping/column which will hold embeddings as defined in the pipeline ")
+	createCmd.Flags().StringVarP(&VectorIndex, "vector-index", "v", "", "Name of mapping/column which will hold embeddings as defined in the pipeline.")
+	createCmd.MarkFlagRequired("vector-index")
+	createCmd.Flags().StringVarP(&Filename, "file", "f", "", "Path of file containing data for semantic search.\n Json file should be of format - \n \t[{\"data_key\":\"data_value\", ..}..{}]")
 	createCmd.MarkFlagRequired("vector-index")
 }
 
-type index struct {
-	Settings struct {
-		IndexKNN        bool   `json:"index.knn"`
-		DefaultPipeline string `json:"default_pipeline"`
-	} `json:"settings"`
-	Mappings struct {
-		Properties []map[string]interface{} `json:"properties"`
-	} `json:"mappings"`
+func InitialseIndex(i *index) {
+	i.Settings.IndexKNN = true
+	i.Settings.DefaultPipeline = Pipeline
+	i.Mappings.Properties = make(map[string]interface{})
 }

--- a/cmd/index/create.go
+++ b/cmd/index/create.go
@@ -4,6 +4,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type index struct {
+	Settings struct {
+		IndexKNN        bool   `json:"index.knn"`
+		DefaultPipeline string `json:"default_pipeline"`
+	} `json:"settings"`
+	Mappings struct {
+		Properties map[string]interface{} `json:"properties"`
+	} `json:"mappings"`
+}
+
 var (
 	Pipeline    string
 	VectorIndex string

--- a/cmd/index/create.go
+++ b/cmd/index/create.go
@@ -1,0 +1,15 @@
+package index
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	createCmd = &cobra.Command{
+		Use:   "create",
+		Short: "Creates a index for semantic search.",
+		Long:  `create (thothica index create) is a tool which helps you to define mappings and create index in opensearch to perform semantic search.`,
+		Run: func(cmd *cobra.Command, args []string) {
+		},
+	}
+)

--- a/cmd/index/index.go
+++ b/cmd/index/index.go
@@ -18,4 +18,5 @@ var (
 
 func init() {
 	IndexCmd.AddCommand(listCmd)
+	IndexCmd.AddCommand(createCmd)
 }

--- a/cmd/search/search.go
+++ b/cmd/search/search.go
@@ -2,17 +2,16 @@ package search
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/Thothica/thothica/internal/opensearch"
-	"github.com/charmbracelet/bubbles/spinner"
-	"github.com/charmbracelet/bubbles/textinput"
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 )
 
 var (
+	Index         string
+	Query         string
+	Size          int
 	c             = opensearch.NewClient()
 	focusedStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
 	blurredStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
@@ -24,164 +23,19 @@ var (
 		Short: "perform semantic search on index.",
 		Long:  "performs semantic search on the provided index.",
 		Run: func(cmd *cobra.Command, args []string) {
-			if _, err := tea.NewProgram(initialModel()).Run(); err != nil {
+			res, err := c.SemanticSearch(Query, Index, Size)
+			if err != nil {
 				cobra.CheckErr(err)
 			}
+			fmt.Println(res)
 		},
 	}
 )
 
-type model struct {
-	focusIndex int
-	inputs     []textinput.Model
-	spinner    spinner.Model
-	loading    bool
-	complete   bool
-}
-
-type SemanticSearchResponse string
-type SemanticSearchError error
-
-func SearchRequest(query, index string) tea.Cmd {
-	return func() tea.Msg {
-		res, err := c.SemanticSearch(query, index, 5)
-		if err != nil {
-			return SemanticSearchError(err)
-		}
-		return SemanticSearchResponse(res)
-	}
-}
-
-func initialModel() model {
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
-
-	m := model{
-		inputs:  make([]textinput.Model, 2),
-		spinner: s,
-	}
-
-	for i := range m.inputs {
-		t := textinput.New()
-		t.CharLimit = 32
-
-		switch i {
-		case 0:
-			t.Placeholder = "Index Name"
-			t.CharLimit = 50
-			t.PromptStyle = focusedStyle
-			t.TextStyle = focusedStyle
-			t.Focus()
-		case 1:
-			t.Placeholder = "Search query"
-			t.CharLimit = 100
-		}
-
-		m.inputs[i] = t
-
-	}
-	return m
-}
-
-func (m model) Init() tea.Cmd {
-	return textinput.Blink
-}
-
-func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c", "esc":
-			return m, tea.Quit
-
-		case "tab", "shift+tab", "enter", "up", "down":
-			s := msg.String()
-
-			if s == "enter" && m.focusIndex == len(m.inputs) {
-				m.loading = true
-				return m, tea.Batch(m.spinner.Tick, SearchRequest(m.inputs[1].Value(), m.inputs[0].Value()))
-			}
-
-			if s == "up" || s == "shift+tab" {
-				m.focusIndex--
-			} else {
-				m.focusIndex++
-			}
-
-			if m.focusIndex > len(m.inputs) {
-				m.focusIndex = 0
-			} else if m.focusIndex < 0 {
-				m.focusIndex = len(m.inputs)
-			}
-
-			cmds := make([]tea.Cmd, len(m.inputs))
-			for idx := range m.inputs {
-				if idx == m.focusIndex {
-					cmds[idx] = m.inputs[idx].Focus()
-					m.inputs[idx].PromptStyle = focusedStyle
-					m.inputs[idx].TextStyle = focusedStyle
-					continue
-				}
-				m.inputs[idx].Blur()
-				m.inputs[idx].PromptStyle = noStyle
-				m.inputs[idx].TextStyle = noStyle
-			}
-
-			return m, tea.Batch(cmds...)
-		}
-	case SemanticSearchResponse:
-        fmt.Println(msg)
-		m.loading = false
-		m.complete = true
-		return m, tea.Quit
-
-	case SemanticSearchError:
-        cobra.CheckErr(msg)
-		return nil, tea.Quit
-
-	default:
-		var cmd tea.Cmd
-		m.spinner, cmd = m.spinner.Update(msg)
-		return m, cmd
-	}
-
-	updateInputs := func(msg tea.Msg) tea.Cmd {
-		cmds := make([]tea.Cmd, len(m.inputs))
-
-		for i := range m.inputs {
-			m.inputs[i], cmds[i] = m.inputs[i].Update(msg)
-		}
-
-		return tea.Batch(cmds...)
-	}(msg)
-
-	return m, updateInputs
-}
-
-func (m model) View() string {
-	var b strings.Builder
-
-	if !m.complete {
-		for i := range m.inputs {
-			b.WriteString(m.inputs[i].View())
-			if i < len(m.inputs)-1 {
-				b.WriteRune('\n')
-			}
-		}
-	}
-
-	button := &blurredButton
-	if m.focusIndex == len(m.inputs) {
-		button = &focusedButton
-	}
-
-	if m.loading {
-		fmt.Fprintf(&b, "\n\n   %s Searching your query...\n\n", m.spinner.View())
-	}
-	if !m.complete {
-		fmt.Fprintf(&b, "\n\n%s\n\n", *button)
-	}
-
-	return b.String()
+func init() {
+	SearchCmd.Flags().StringVarP(&Index, "index", "i", "", "Index on which semantic search will be performed.")
+	SearchCmd.MarkFlagRequired("index")
+	SearchCmd.Flags().StringVarP(&Query, "query", "q", "", "Query for semantic search.")
+	SearchCmd.MarkFlagRequired("query")
+	SearchCmd.Flags().IntVarP(&Size, "size", "s", 5, "Result size for returning response.")
 }

--- a/cmd/search/search.go
+++ b/cmd/search/search.go
@@ -131,16 +131,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(cmds...)
 		}
 	case SemanticSearchResponse:
-		fmt.Println(msg)
+        fmt.Println(msg)
 		m.loading = false
 		m.complete = true
 		return m, tea.Quit
 
 	case SemanticSearchError:
-		fmt.Println(msg)
-		m.loading = false
-		m.complete = true
-		return m, tea.Quit
+        cobra.CheckErr(msg)
+		return nil, tea.Quit
 
 	default:
 		var cmd tea.Cmd

--- a/internal/opensearch/index.go
+++ b/internal/opensearch/index.go
@@ -1,0 +1,35 @@
+package opensearch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/opensearch-project/opensearch-go/opensearchapi"
+)
+
+func (c Client) CreateIndex(Body, Index string) (string, error) {
+	req := opensearchapi.IndicesCreateRequest{
+		Index: Index,
+		Body:  strings.NewReader(Body),
+	}
+
+	res, err := req.Do(context.Background(), c.Client)
+	if err != nil {
+		return "", err
+	}
+
+	var resp map[string]interface{}
+	err = json.NewDecoder(res.Body).Decode(&resp)
+	resopnse, err := json.MarshalIndent(resp, "", " ")
+	if err != nil {
+		return "", err
+	}
+
+	if res.Status() != "200 OK" {
+		return "", fmt.Errorf("opensearch returned error\n %s", string(resopnse))
+	}
+
+	return string(resopnse), nil
+}

--- a/internal/opensearch/search.go
+++ b/internal/opensearch/search.go
@@ -50,7 +50,7 @@ func (c Client) SemanticSearch(query, index string, size int) (string, error) {
 
 	data := searchResponse["hits"].(map[string]interface{})["hits"].([]interface{})
 
-	searchResults, err := json.MarshalIndent(data, "", "\t")
+	searchResults, err := json.MarshalIndent(data, "", " ")
 	if err != nil {
 		return "", err
 	}

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -1,0 +1,22 @@
+username=""
+password=""
+endpoint=""
+pipeline="-pipeline"
+curl -XPUT "https://$endpoint:9200/_ingest/pipeline/$pipeline" \
+	-u "$username:$password" \
+	-k \
+	-H "Content-Type: application/json" \
+	-d'
+	{
+		"description": "embedding pipeline",
+		"processors": [
+			{
+			"text_embedding": {
+				"model_id": "AbDZGo8BB3UUeZ_94CHA",
+				"field_map": {
+					"Raw_Response": "Raw_Response_embedding"
+					}
+				}
+			}
+		]
+	}'


### PR DESCRIPTION
index create command is complete.
Now just clean things up.
  1) Add global default-model-id in configuration for all clusters.
  2) Add pipeline list and pipeline create no bubbletea.

- **Added create command**
- **sample api to create new embedding pipeline**
- **Added cli model**
- **removed bubble Idea changed, now will use reflect on json types to first make a index json from it and give it to user so they can change and then send request with it.**
- **Displayed nicer json of results**
- **Fixed indexStruct**
- **Initialised Index**
- **Added type reflection**
- **Made createIndex function**
- **Better formatting still use jq**
- **removed tea from search was useless this is better**
- **index create complete. works beautifully**
